### PR TITLE
Preserve copyright headers, include GitHub link and version in output

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,9 +1,18 @@
 const merge = require('webpack-merge');
 const UglifyJsWebpackPlugin = require('uglifyjs-webpack-plugin');
 const common = require('./webpack.common');
+const package = require('./package.json');
 
 module.exports = merge(common, {
     plugins: [
-        new UglifyJsWebpackPlugin()
+        new UglifyJsWebpackPlugin({
+            uglifyOptions: {
+                output: {
+                    preamble: "/* https://github.com/Microsoft/WebPerfToolbar v" + package.version + " */",
+                    // Don't let uglify remove important comments
+                    comments: /copyright|license|preserve|\/\*\!/gi,
+                },
+            },
+        })
     ]
 });


### PR DESCRIPTION
We need to keep copyright headers in the output. Also add a preamble to the output that includes a link to this GitHub repo and the version of the compiled file.